### PR TITLE
feat: 실시간 채팅 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@nestjs/common": "^11.0.9",
         "@nestjs/core": "^11.0.9",
         "@nestjs/platform-express": "^11.0.9",
+        "@nestjs/platform-socket.io": "^11.0.9",
         "@nestjs/sequelize": "^11.0.0",
         "@nestjs/websockets": "^11.0.9",
         "@prisma/client": "^6.3.1",
@@ -1708,6 +1709,24 @@
       "peerDependencies": {
         "@nestjs/common": "^11.0.0",
         "@nestjs/core": "^11.0.0"
+      }
+    },
+    "node_modules/@nestjs/platform-socket.io": {
+      "version": "11.0.9",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.0.9.tgz",
+      "integrity": "sha512-H+wTOollSZ1GSAp2+UIl4x+rYutkrH0poYeeo/+Dr8AwobghZuSGxoQ3FpqIurI/NuwBoBdFJV7cm7v9mlKkuw==",
+      "dependencies": {
+        "socket.io": "4.8.1",
+        "tslib": "2.8.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/websockets": "^11.0.0",
+        "rxjs": "^7.1.0"
       }
     },
     "node_modules/@nestjs/schematics": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@nestjs/common": "^11.0.9",
     "@nestjs/core": "^11.0.9",
     "@nestjs/platform-express": "^11.0.9",
+    "@nestjs/platform-socket.io": "^11.0.9",
     "@nestjs/sequelize": "^11.0.0",
     "@nestjs/websockets": "^11.0.9",
     "@prisma/client": "^6.3.1",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,6 +69,7 @@ model user {
   created_at   DateTime? @default(now()) @db.Timestamp(0)
   updated_at   DateTime? @default(now()) @db.Timestamp(0)
   tickets      ticket[]
+  messages     message[] 
 }
 
 model address {
@@ -119,5 +120,14 @@ model screen {
   created_at    DateTime? @default(now()) @db.Timestamp(0)
   update_at     DateTime? @default(now()) @db.Timestamp(0)
   schedules     schedule[]
+}
 
+model message {
+  id       BigInt @id @default(autoincrement())
+  user_id  BigInt
+  message  String @db.Text
+  is_admin Int?   @db.TinyInt
+  user     user    @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  created_at DateTime? @default(now()) @db.Timestamp(0)
+  updated_at DateTime? @default(now()) @db.Timestamp(0)
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
 import { MovieModule } from './movie/movie.module';
-import { PrismaService } from '../prisma/prisma.service'; // PrismaService import
-
+import { PrismaService } from '../prisma/prisma.service';
+import { TicketModule } from './ticket/ticket.module';
+import { ScheduleModule } from './schedule/schedule.module';
+import { TheaterModule } from './theater/theater.module';
+import { ChatModule } from './chat/chat.module';
 @Module({
-  imports: [MovieModule],
-  providers: [PrismaService], // PrismaService를 providers에 추가
+  imports: [MovieModule, TicketModule, ScheduleModule, TheaterModule,ChatModule],
+  providers: [PrismaService],
 })
 export class AppModule {}

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { ChatService } from './chat.service';
+
+@Controller('chat')
+export class ChatController {
+  constructor(private readonly chatService: ChatService) {}
+
+  // 특정 유저의 채팅 내역 조회
+  @Get(':userId')
+  getUserMessages(@Param('userId') userId: number) {
+    return this.chatService.getUserMessages(userId);
+  }
+}

--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -1,0 +1,48 @@
+import {
+  WebSocketGateway,
+  SubscribeMessage,
+  MessageBody,
+  WebSocketServer,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+import { ChatService } from './chat.service';
+
+@WebSocketGateway({ cors: { origin: '*' } })
+export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
+  constructor(private readonly chatService: ChatService) {}
+
+  @WebSocketServer()
+  server: Server;
+
+  handleConnection(client: Socket) {
+    console.log(`Client connected: ${client.id}`);
+  }
+
+  handleDisconnect(client: Socket) {
+    console.log(`Client disconnected: ${client.id}`);
+  }
+
+  @SubscribeMessage('sendMessage')
+  async handleMessage(
+    @MessageBody()
+    data: {
+      userId: number;
+      message: string;
+      isAdmin?: boolean;
+    },
+  ) {
+    const savedMessage = await this.chatService.saveMessage(
+      data.userId,
+      data.message,
+    );
+    const userIdString = data.userId.toString();
+
+    if (data.isAdmin) {
+      this.server.emit('newMessage', savedMessage);
+    } else {
+      this.server.to(userIdString).emit('newMessage', savedMessage);
+    }
+  }
+}

--- a/src/chat/chat.module.ts
+++ b/src/chat/chat.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ChatGateway } from './chat.gateway';
+import { ChatService } from './chat.service';
+import { ChatController } from './chat.controller';
+import { PrismaService } from '../../prisma/prisma.service'; 
+
+@Module({
+  providers: [ChatGateway, ChatService, PrismaService],
+  controllers: [ChatController],
+  exports: [ChatService],
+})
+export class ChatModule {}

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+
+@Injectable()
+export class ChatService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  // 메시지 저장
+  async saveMessage(user_id: number, message: string) {
+    return this.prisma.message.create({
+      data: {
+        user_id,
+        message,
+      },
+    });
+  }
+
+  // 유저의 채팅 내역 조회
+  async getUserMessages(userId: number) {
+    return this.prisma.message.findMany({
+      where: {
+        user_id: userId,
+      },
+      orderBy: {
+        created_at: 'desc',
+      },
+    });
+  }
+}


### PR DESCRIPTION
# 구현
####  WebSocket을 이용한 실시간 채팅 구현
- socket.io를 활용하여 실시간 메시지 송수신 기능 추가
- 사용자 간 실시간 채팅을 지원하기 위한 ChatGateway 생성
#### Prisma를 이용한 메시지 저장 기능 추가

- 채팅 메시지를 데이터베이스에 저장하도록 ChatService 구현
- user_id, message, is_admin을 저장하여 관리
- 사용자의 채팅 내역을 조회할 수 있도록 getUserMessages 메서드 추가
#### 채팅 이벤트 처리
- sendMessage 이벤트로 메시지를 전송하면, 모든 클라이언트에 전달
- 관리자가 보낸 메시지는 모든 사용자에게, 일반 사용자의 메시지는 해당 사용자에게만 전송
#### 채팅 관련 DB 스키마 추가 (message 테이블)
- message 테이블에 user_id, message, is_admin, created_at 등의 필드 추가
- user_id를 user 테이블과 관계 설정 (@relation(fields: [user_id], references: [id]))
# 기대 효과
#### 실시간 채팅 지원
사용자 간 실시간 채팅이 가능하여 원활한 커뮤니케이션 제공
#### 채팅 내역 저장 및 조회
Prisma를 통해 사용자 메시지를 저장하고, 특정 사용자의 채팅 내역을 불러올 수 있음
#### 관리자 메시지 기능
관리자가 전체 사용자에게 메시지를 보낼 수 있도록 기능 추가
# 관련 코드
- ChatGateway: WebSocket 이벤트 (sendMessage, newMessage) 처리
- ChatService: 메시지 저장 및 조회 기능 추가
- message 테이블 스키마 수정 (prisma/schema.prisma 변경)